### PR TITLE
add: ansible.cfg to format playbook output

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+stdout_callback=yaml


### PR DESCRIPTION
Figured it might help students more easily understand what is going on if their ansible playbook output was formatted with the "stdout_callback=yaml" plugin. Of course this significantly lengthens the output from ansible but I find really helps to parse through the gobble dee goop that comes out. Especially since one of those tasks has to update what looks like 200 packages :joy: 

The only other change you would need to make is amending the ansible commands to utilize a single -v flag as such,

```bash
ansible-playbook -v -i /root/HPC_Deploy/hosts 03_package_update_or_install.yaml

ansible-playbook -v -i /root/HPC_Deploy/hosts /root/HPC_Deploy/04_enterprise_patching.yaml
```

Would look as follows:
![suggestion](https://github.com/user-attachments/assets/c9e400b1-c169-40df-8629-4544a03c269e)
![suggestion2](https://github.com/user-attachments/assets/ff3522fe-5879-4224-9bcf-21f739898dae)

Just suggestions, as far as the offer to send a humble book bundle my way save if for the next studious committer who comes up with something more substantial. I don't feel this contribution merits a whole bundle of security books. 

Thanks for all the labs/course material you do sir! See you around